### PR TITLE
v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Changelog 🔄
 All notable changes to `persist-cache` will be documented here. This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.2.0] - 2024-03-18
 ### Added
 - Stale calls are now flushed when initialising a cache.
 
@@ -26,5 +26,6 @@ All notable changes to `persist-cache` will be documented here. This project adh
 ### Added
 - Added the `cache()` decorator, which locally and persistently caches functions.
 
+[0.2.0]: https://github.com/umarbutler/persist-cache/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/umarbutler/persist-cache/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/umarbutler/persist-cache/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `persist-cache` will be documented here. This project adh
 ### Added
 - Stale calls are now flushed when initialising a cache.
 
+### Changed
+- Switched hashing algorithm from `XXH3` to `XXH128` and began suffixing hashes with the length of their input to significantly reduce the already very low likelihood of hash collisions.
+- Pickle data is now compressed with LZ4 to speed up IO and reduce disk usage.
+
+### Removed
+- Removed unused import of `asyncio` in `persist_cache.py`.
+
 ## [0.1.1] - 2024-03-14
 ### Added
 - Added a unit test for passing a custom name to `cache()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Changelog 🔄
 All notable changes to `persist-cache` will be documented here. This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Stale calls are now flushed when initialising a cache.
+
 ## [0.1.1] - 2024-03-14
 ### Added
 - Added a unit test for passing a custom name to `cache()`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## Features 🎯
 - **⚡ Lightning-fast**: a function call can be cached in as little as 145 microseconds and be returned back in as few as 95 microseconds.
 - **💽 Persistent**: cached returns persist across sessions and are stored locally.
-- **⌛ Stale-free**: cached returns may be given shelf lives, after which they will be automatically flushed out.
+- **⌛ Stale-free**: cached returns may be given a shelf life, after which they will be automatically flushed out.
 - **🦺 Process- and thread-safe**: interprocess file locks prevent processes and threads from writing over each other.
 - **⏱️ Async-compatible**: asynchronous functions can be cached with the same decorator as synchronous ones.
 - **👨‍🏫 Class-compatible**: methods can be cached with the same decorator as functions (although the `self` argument is always ignored).
@@ -18,7 +18,7 @@ pip install persist-cache
 ```
 
 ## Usage 👩‍💻
-The code snippet below demonstrates how both synchronous and asynchronous functions as well as methods can be cached with `persist-cache`:
+The code snippet below demonstrates how both synchronous and asynchronous functions as well as methods may be cached with `persist-cache`:
 ```python
 from persist_cache import cache
 
@@ -36,7 +36,7 @@ class MyClass:
     async def my_method(self): ...
 ```
 
-It is also possible to name caches and specify their shelf lives:
+It is also possible to name caches and specify their shelf life:
 ```python
 from datetime import timedelta
 
@@ -47,7 +47,7 @@ def my_function(): ...
 def my_other_function(): ...
 ```
 
-Once created, cached functions can be managed as follows:
+Once created, cached functions may be managed as follows:
 ```python
 my_function.set_expiry(60 * 60) # Change cached returns to expire after an hour.
 my_function.flush_cache() # Flush out any expired cached returns.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ async def my_function(): ...
 class MyClass:
     @cache
     def my_method(self): ...
+
+    @cache
+    async def my_method(self): ...
 ```
 
 It is also possible to name caches and specify their shelf lives:
@@ -80,5 +83,5 @@ After being wrapped, the cached function will have the following methods attache
 - `clear_cache() -> None`: Clears out all cached returns.
 - `delete_cache() -> None`: Deletes the cache.
 
-## License 📜
-This library is licensed under the [MIT License](https://github.com/umarbutler/persist-cache/blob/main/LICENCE).
+## Licence 📜
+This library is licensed under the [MIT Licence](https://github.com/umarbutler/persist-cache/blob/main/LICENCE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "persist-cache"
-version = "0.1.1"
+version = "0.2.0"
 authors = [
   {name="Umar Butler", email="umar@umar.au"},
 ]

--- a/src/persist_cache/caching.py
+++ b/src/persist_cache/caching.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from typing import Any, Union
 
 from filelock import FileLock
-from xxhash import xxh3_64_hexdigest
+from xxhash import xxh3_128_hexdigest
 
 from .serialization import deserialize, serialize
 
@@ -52,7 +52,11 @@ def get(key: str, dir: str, expiry: Union[int, float, timedelta, None] = None) -
 def hash(data: Any) -> str:
     """Hash the given data."""
 
-    return xxh3_64_hexdigest(serialize(data))
+    # Serialise the data.
+    data = serialize(data)
+    
+    # Hash the data and affix its length, preceded by a hyphen (to reduce the likelihood of collisions).
+    return f'{xxh3_128_hexdigest(data)}-{len(data)}'
 
 def delete(dir: str) -> None:
     """Delete the provided cache."""

--- a/src/persist_cache/persist_cache.py
+++ b/src/persist_cache/persist_cache.py
@@ -1,4 +1,3 @@
-import asyncio
 import inspect
 import os
 from datetime import timedelta

--- a/src/persist_cache/persist_cache.py
+++ b/src/persist_cache/persist_cache.py
@@ -47,6 +47,10 @@ def cache(
         if not os.path.exists(dir):
             os.makedirs(dir, exist_ok=True)
         
+        # If an expiry has been set, flush out any expired cached returns.
+        if expiry is not None:
+            caching.flush(dir, expiry)
+        
         # Flag whether the function is a method to enable the exclusion of the first argument (which will be the instance of the function's class) from being hashed to produce the cache key.
         is_method = inspect.ismethod(func)
         

--- a/src/persist_cache/pickle.py
+++ b/src/persist_cache/pickle.py
@@ -1,0 +1,12 @@
+import dill as pickle
+import lz4.frame
+
+from functools import wraps
+
+@wraps(pickle.dumps)
+def dumps(*args, **kwargs):
+    return lz4.frame.compress(pickle.dumps(*args, **kwargs))
+
+@wraps(pickle.loads)
+def loads(*args, **kwargs):
+    return pickle.loads(lz4.frame.decompress(*args, **kwargs))

--- a/src/persist_cache/serialization.py
+++ b/src/persist_cache/serialization.py
@@ -1,7 +1,7 @@
 from typing import Any, Union
 
-import dill as pickle
 import msgspec
+import pickle
 
 Msgpackables = Union[str, int, list, dict, bool, float, None]
 """Types that are directly msgpackable."""


### PR DESCRIPTION
### Added
- Stale calls are now flushed when initialising a cache.

### Changed
- Switched hashing algorithm from `XXH3` to `XXH128` and began suffixing hashes with the length of their input to significantly reduce the already very low likelihood of hash collisions.
- Pickle data is now compressed with LZ4 to speed up IO and reduce disk usage.

### Removed
- Removed unused import of `asyncio` in `persist_cache.py`.