### PR TITLE
Avoid infinite .lock extension in filenames

### DIFF
--- a/src/persist_cache/caching.py
+++ b/src/persist_cache/caching.py
@@ -1,3 +1,4 @@
+import re
 import os
 import shutil
 from datetime import datetime, timedelta
@@ -87,6 +88,9 @@ def flush(dir: str, expiry: Union[int, float, timedelta, None]) -> None:
     
     # Iterate over keys in the cache.
     for file in os.listdir(dir):
+        if re.match(r'^.+\.lock$', file):
+            continue
+
         path = f'{dir}/{file}'
         
         # Lock the entry before reading it.


### PR DESCRIPTION
Every time that you run a cached function and the function wants to search for expired files it creates another lock file with an extra `.lock` extension in the filename due to the use of the lock file in the `FileLock`


![image](https://github.com/umarbutler/persist-cache/assets/28605214/8c2d158b-acba-4484-baa0-36984f9649db)
